### PR TITLE
Different ICUs during for the same ICUSTAY_ID

### DIFF
--- a/_posts/2015-04-22-icustayevents.md
+++ b/_posts/2015-04-22-icustayevents.md
@@ -12,7 +12,7 @@ The ```ICUSTAYEVENTS``` table is generated from the ```CENSUSEVENTS``` table. An
 times during one hospital admission. For these cases, we set the
 following rule regarding ```ICUSTAY_ID```s:
 
-**For patients transferred out of ICU units but re-admitted to the same ICU care unit within 24 hours, it is considered as one ICUSTAY event with the same ```ICUSTAY_ID```. However, if the patient was re-admitted back to the same ICU care unit after 24 hours, it is considered as a new ICUSTAY event and is assigned a new ```ICUSTAY_ID```**.
+**For patients transferred out of ICU units but re-admitted to the same or different ICU care unit within 24 hours, it is considered as one ICUSTAY event with the same ```ICUSTAY_ID```. However, if the patient was re-admitted back to the same or different ICU care unit after 24 hours, it is considered as a new ICUSTAY event and is assigned a new ```ICUSTAY_ID```**.
 
 Column name | Data type | New Column | Remarks
 --- | --- | --- | ---


### PR DESCRIPTION
Patients retain the same ICUSTAY_ID despite moving units if no gap
longer than 24 hours:
(see https://github.com/mimic2/v3.0/issues/42)